### PR TITLE
bugfix/110.inactive-project-titles

### DIFF
--- a/src/modules/NProjects/ui/components/ProjectCard/ProjectCard.module.css
+++ b/src/modules/NProjects/ui/components/ProjectCard/ProjectCard.module.css
@@ -8,6 +8,7 @@
     min-width: 110px;
     transition: flex 0.5s ease-out;
     flex: 2;
+    overflow: hidden;
 }
 
 .container.active {


### PR DESCRIPTION
https://trello.com/c/CBFzK717/110-inactive-project-titles

убрал overflow заголовкам неактивных проектов на десктоп версии. Теперь не вылетают за пределы карточки